### PR TITLE
feat: 알림 타입 정리 및 조회/상세조회 Swagger 명세 추가

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -2819,13 +2819,73 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /api/v1/notifications:
+  get:
+    tags:
+      - Notifications
+    summary: 알림 목록 조회
+    description: 로그인한 사용자의 모든 알림을 최신순으로 조회합니다.
+    security:
+      - bearerAuth: []
+    responses:
+      '200':
+        description: 알림 목록 조회 성공
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: 알림 목록 조회 성공
+                data:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      notificationId:
+                        type: integer
+                        example: 42
+                      title:
+                        type: string
+                        example: 스탬프 적립 조건이 변경됐어요!
+                      content:
+                        type: string
+                        example: 8월 1일부터 스탬프는 5,000원 이상 결제 시 적립됩니다.
+                      type:
+                        type: string
+                        enum: [cafe, stamp, review]
+                      isRead:
+                        type: boolean
+                        example: false
+                      createdAt:
+                        type: string
+                        format: date-time
+                        example: 2025-07-31T13:12:00.000Z
+                      cafe:
+                        type: object
+                        nullable: true
+                        properties:
+                          id:
+                            type: integer
+                            example: 3
+                          name:
+                            type: string
+                            example: 루피커피
+      '401':
+        description: 인증 실패 (JWT 누락 또는 만료)
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ErrorResponse'
+
   
   /api/v1/notification/{notificationId}:
     get:
       tags:
         - Notifications
       summary: 알림 상세 조회
-      description: 알림 ID를 기반으로 상세 정보를 조회합니다. 읽지 않은 알림이라면 읽음 처리됩니다.
+      description: 알림 ID를 기반으로 상세 정보를 조회합니다. 읽지 않은 알림이라면 읽음 처리됩니다. 모든 알림 유형은 관련된 카페 상세페이지로 이동됩니다.
       security:
         - bearerAuth: []
       parameters:
@@ -2852,15 +2912,13 @@ paths:
                       notificationId:
                         type: integer
                         example: 12
-                      title:
-                        type: string
-                        example: 오늘의 챌린지가 시작됐어요!
                       type:
                         type: string
-                        enum: [system, challenge, stamp, review, coupon]
+                        enum: [cafe, stamp, review]
                       createdAt:
                         type: string
                         format: date-time
+                        example: 2025-07-31T12:34:56.000Z
                       cafe:
                         type: object
                         nullable: true
@@ -2871,13 +2929,9 @@ paths:
                           name:
                             type: string
                             example: 루피커피
-                      detail:
-                        oneOf:
-                          - $ref: '#/components/schemas/SystemNotificationDetail'
-                          - $ref: '#/components/schemas/ChallengeNotificationDetail'
-                          - $ref: '#/components/schemas/StampNotificationDetail'
-                          - $ref: '#/components/schemas/ReviewNotificationDetail'
-                          - $ref: '#/components/schemas/CouponNotificationDetail'
+                          address:
+                            type: string
+                            example: 서울시 성북구 성북로 123
         '404':
           description: 알림이 존재하지 않음
           content:
@@ -2885,6 +2939,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  
   /api/v1/cafes/{cafeId}/my-stamp:
   get:
     summary: 카페 내 내 스탬프 현황 조회
@@ -5009,6 +5064,19 @@ components:
           expiredAt:
             type: string
             format: date-time
+            
+    CafeInfo:
+      type: object
+      properties:
+        id:
+          type: integer
+          example: 1
+        name:
+          type: string
+          example: 루피커피
+        address:
+          type: string
+          example: 서울시 성북구 성북로 123
 
     UserCoupon:
       type: object

--- a/prisma/migrations/20250729113300_add_discount_type_enum/migration.sql
+++ b/prisma/migrations/20250729113300_add_discount_type_enum/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `discount_type` on the `coupon_templates` table. All the data in the column will be lost.
+  - Added the required column `type` to the `coupon_templates` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE `coupon_templates` DROP COLUMN `discount_type`,
+    ADD COLUMN `type` ENUM('DISCOUNT', 'FREE_ITEM', 'SIZE_UP') NOT NULL,
+    MODIFY `discount_value` INTEGER NULL;

--- a/prisma/migrations/20250731085133_change_notification_type/migration.sql
+++ b/prisma/migrations/20250731085133_change_notification_type/migration.sql
@@ -1,0 +1,25 @@
+/*
+  Warnings:
+
+  - The values [system,challenge,coupon] on the enum `notifications_type` will be removed. If these variants are still used in the database, this will fail.
+  - Added the required column `category` to the `cafe_menu` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `valid_days` to the `coupon_templates` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE `cafe_menu` ADD COLUMN `category` VARCHAR(100) NOT NULL;
+
+-- AlterTable
+ALTER TABLE `challenge_participants` ADD COLUMN `joined_cafe_id` INTEGER NULL;
+
+-- AlterTable
+ALTER TABLE `coupon_templates` ADD COLUMN `valid_days` INTEGER NOT NULL;
+
+-- AlterTable
+ALTER TABLE `notifications` MODIFY `type` ENUM('cafe', 'stamp', 'review') NOT NULL;
+
+-- AlterTable
+ALTER TABLE `stamp_books` ADD COLUMN `round` INTEGER NOT NULL DEFAULT 1;
+
+-- AddForeignKey
+ALTER TABLE `challenge_participants` ADD CONSTRAINT `challenge_participants_joined_cafe_id_fkey` FOREIGN KEY (`joined_cafe_id`) REFERENCES `cafes`(`id`) ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -383,16 +383,16 @@ model Notification {
 }
 
 model CouponTemplate {
-  id               Int        @id @default(autoincrement())
-  cafeId           Int        @map("cafe_id")
-  name             String     @db.VarChar(255)
-  validDays        Int        @map("valid_days")
-  discountType     String     @map("discount_type") @db.VarChar(20) // "AMOUNT" | "PERCENTAGE"
-  discountValue    Int        @map("discount_value") // 금액(원) 또는 퍼센트
-  applicableMenuId Int?       @map("applicable_menu_id")
-  isActive         Boolean    @default(true) @map("is_active")
-  expiredAt        DateTime   @map("expired_at")
-  createdAt        DateTime   @default(now()) @map("created_at")
+  id               Int          @id @default(autoincrement())
+  cafeId           Int          @map("cafe_id")
+  name             String       @db.VarChar(255)
+  validDays        Int          @map("valid_days")
+  discountType     DiscountType @map("type") // "DISCOUNT" | "FREE_ITEM" | "SIZE_UP"
+  discountValue    Int?         @map("discount_value")       // DISCOUNT일 때만 사용
+  applicableMenuId Int?         @map("applicable_menu_id")   // FREE_ITEM, SIZE_UP일 때만 사용
+  isActive         Boolean      @default(true) @map("is_active")
+  expiredAt        DateTime     @map("expired_at")
+  createdAt        DateTime     @default(now()) @map("created_at")
   
   // Relations
   cafe            Cafe           @relation(fields: [cafeId], references: [id], onDelete: Cascade)
@@ -466,6 +466,12 @@ enum NotificationType {
   stamp
   coupon
   review
+}
+
+enum DiscountType {
+  DISCOUNT     // 금액 할인
+  FREE_ITEM    // 특정 메뉴 무료 제공
+  SIZE_UP      // 사이즈 업그레이드
 }
 
 enum CouponStatus {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -467,11 +467,9 @@ enum CafeStatus {
 }
 
 enum NotificationType {
-  system
-  challenge
-  stamp
-  coupon
-  review
+  cafe   // 단골 카페 사장이 보낸 알림
+  stamp  // 스탬프 정책 변경시 알림
+  review // 스탬프 찍으면, 리뷰 작성하라고 알림
 }
 
 enum DiscountType {

--- a/src/controllers/notification.controller.js
+++ b/src/controllers/notification.controller.js
@@ -42,26 +42,26 @@ export const getUserNotifications = async (req, res) => {
 };
 
 export const getNotificationById = async (req, res) => {
-    const userId = req.user.id;
-    const notificationId = parseInt(req.params.notificationId);
-  
-    const notification = await prisma.notification.findUnique({
-      where: { id: notificationId },
-      include: {
-        cafe: {
-          select: {
-            id: true,
-            name: true,
-          },
+  const userId = req.user.id;
+  const notificationId = parseInt(req.params.notificationId);
+
+  const notification = await prisma.notification.findUnique({
+    where: { id: notificationId },
+    include: {
+      cafe: {
+        select: {
+          id: true,
+          name: true,
+          address: true,
         },
       },
-    });
+    },
+  });
 
   if (!notification) {
     throw new NotificationNotFoundError(notificationId);
   }
 
-  // 2. 읽음 처리 (읽지 않았을 때만)
   if (!notification.isRead) {
     await prisma.notification.update({
       where: { id: notificationId },
@@ -69,118 +69,13 @@ export const getNotificationById = async (req, res) => {
     });
   }
 
-  // 3. 유형별 상세정보 동적 처리
-  let detail = null;
-
-  switch (notification.type) {
-    case "challenge":
-        if (!notification.cafeId) {
-            detail = [];
-            break;
-        }
-
-        detail = await prisma.challenge.findMany({
-            where: {
-            availableCafes: {
-                some: {
-                cafeId: notification.cafeId, // 해당 카페의 챌린지로 이동
-                },
-            },
-            },
-            select: {
-            id: true,
-            title: true,
-            description: true,
-            thumbnailUrl: true,
-            startDate: true,
-            endDate: true,
-            isActive: true,
-            },
-        });
-        break;
-
-    case "stamp":
-      detail = await prisma.stampBook.findFirst({ // 해당 카페의 스탬프북으로 이동
-        where: {
-          userId,
-          cafeId: notification.cafeId,
-        },
-        select: {
-          id: true,
-          currentCount: true,
-          goalCount: true,
-          rewardDetail: true,
-          status: true,
-          isCompleted: true,
-          isConverted: true,
-          expiresAt: true,
-          lastVisitedAt: true,
-        },
-      });
-      break;
-
-    case "review":
-        if (!notification.cafeId) {
-          detail = null;
-          break;
-        }
-      
-        const cafe = await prisma.cafe.findUnique({
-          where: { id: notification.cafeId }, // 카페 상세 페이지로 이동
-          select: {
-            id: true,
-            name: true,
-            address: true,
-          },
-        });
-      
-        detail = cafe;
-        break;
-
-        case "coupon":
-          if (!notification.cafeId) {
-            detail = [];
-            break;
-          }
-        
-          detail = await prisma.couponTemplate.findMany({ // 해당 카페의 쿠폰 템플릿으로 이동
-            where: {
-              cafeId: notification.cafeId,
-              isActive: true,
-            },
-            select: {
-              id: true,
-              name: true,
-              validDays: true,
-              discountType: true,
-              discountValue: true,
-              applicableMenuId: true,
-              expiredAt: true,
-            },
-          });
-        
-          break;
-        
-        
-    case "system":
-      default:
-        detail = {
-          title: notification.title,  // 알림 제목
-          content: notification.content, // 알림 내용
-        };
-        break;
-        
-  }
-
   return res.success({
     message: "알림 상세 조회 성공",
     data: {
       notificationId: notification.id,
-      title: notification.title,
       type: notification.type,
       createdAt: notification.createdAt,
       cafe: notification.cafe ?? null,
-      detail,
     },
-    });
-}
+  });
+};

--- a/src/routes/notification.routes.js
+++ b/src/routes/notification.routes.js
@@ -12,6 +12,8 @@ const router = express.Router();
 // 모든 알림 API는 인증 필요
 router.use(authenticateJWT);
 
+router.get("/notifications", getUserNotifications); // 알림 목록 조회
+
 // 알림 상세 조회 -> 알림 읽음 처리
 router.get("/notification/:notificationId", getNotificationById);
 


### PR DESCRIPTION
## 📌 작업 개요
알림 타입 정리 및 알림 조회/상세조회 Swagger 명세 추가

## ✅ 작업 상세 내용
- NotificationType enum을 cafe, stamp, review 3가지로 통일
- 알림 목록 조회 (GET /api/v1/notifications) Swagger 명세 추가
- 알림 상세 조회 (GET /api/v1/notification/{notificationId}) Swagger 명세 추가
- Prisma schema 수정 및 마이그레이션 적용

## 🔍 테스트 및 확인 사항
- 알림 목록 및 상세 조회 응답 형식 Swagger 기준에 맞게 확인

## 📂 관련 이슈
- Close #이슈번호 또는 관련된 이슈 번호 명시

## 🙋 기타 참고 사항
- 프론트에서 카페 상세 페이지로 연결 시 cafe.id 활용 가능
