### PR TITLE
fix: 리뷰 작성 조건 인증 및 API 경로 수정

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -3206,45 +3206,45 @@ paths:
         '500':
           description: 서버 오류
 
-  delete:
-    tags:
-      - Review
-    summary: 리뷰 삭제
-    description: 본인이 작성한 리뷰만 삭제할 수 있습니다.
-    security:
-      - bearerAuth: []
-    parameters:
-      - name: reviewId
-        in: path
-        required: true
-        schema:
-          type: integer
-        description: 삭제할 리뷰 ID
-    responses:
-      '200':
-        description: 리뷰 삭제 성공
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                message:
-                  type: string
-                  example: 리뷰 삭제 성공!
-      '403':
-        description: 권한 없음
-        content:
-          application/json:
-            example:
-              value: { errorCode: "R004", reason: "본인의 리뷰만 수정/삭제할 수 있습니다." }
-      '404':
-        description: 리뷰 없음
-        content:
-          application/json:
-            example:
-              value: { errorCode: "R003", reason: "ID 123에 해당하는 리뷰가 존재하지 않습니다." }
-      '500':
-        description: 서버 오류
+    delete:
+      tags:
+        - Review
+      summary: 리뷰 삭제
+      description: 본인이 작성한 리뷰만 삭제할 수 있습니다.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: reviewId
+          in: path
+          required: true
+          schema:
+            type: integer
+          description: 삭제할 리뷰 ID
+      responses:
+        '200':
+          description: 리뷰 삭제 성공
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: 리뷰 삭제 성공!
+        '403':
+          description: 권한 없음
+          content:
+            application/json:
+              example:
+                value: { errorCode: "R004", reason: "본인의 리뷰만 수정/삭제할 수 있습니다." }
+        '404':
+          description: 리뷰 없음
+          content:
+            application/json:
+              example:
+                value: { errorCode: "R003", reason: "ID 123에 해당하는 리뷰가 존재하지 않습니다." }
+        '500':
+          description: 서버 오류
 
   /api/v1/users/me/reviews:
     get:

--- a/src/config/passport.js
+++ b/src/config/passport.js
@@ -18,7 +18,7 @@ passport.use(
     console.log("🔥 [jwtPayload]:", jwtPayload);
     try {
       const user = await prisma.user.findUnique({
-        where: { id: parseInt(jwtPayload.userId, 10) },
+        where: { id: parseInt(jwtPayload.id, 10) },
       });
 
       if (user) {

--- a/src/middlewares/verifyStamp.js
+++ b/src/middlewares/verifyStamp.js
@@ -17,7 +17,7 @@ export const verifyStamp = async (req, res, next) => {
 
     // 없으면 인증 실패
     if (!stampBook) {
-      return next(new NotAuthenticatedError());
+      return next(new NoActiveStampError(userId, cafeId));
     }
     
     // 2. 스탬프가 적어도 1개 이상 있는지 확인

--- a/src/routes/review.routes.js
+++ b/src/routes/review.routes.js
@@ -19,10 +19,10 @@ router.use(authenticateJWT);
 router.post("/cafe/:cafeId/review", upload.array("images", 5), validateReview, verifyStamp, createReview);
 
 // 리뷰 수정
-router.patch("/:reviewId", validateReview, updateReview);
+router.patch("/reviews/:reviewId", validateReview, updateReview);
 
 // 리뷰 삭제
-router.delete("/:reviewId", deleteReview);
+router.delete("/reviews/:reviewId", deleteReview);
 
 // 내 리뷰 목록 조회
 router.get("/users/me/reviews", getMyReviews);


### PR DESCRIPTION
## 📌 작업 개요
- 리뷰 작성 관련 인증 및 API 경로 수정

## ✅ 작업 상세 내용
- JWT payload의 userId → id 필드로 수정 (인증 오류 해결)
- 리뷰 수정·삭제 API 경로를 /reviews/:reviewId로 통일
- 스탬프북 없을 때 반환되는 에러를 인증 에러 → 도메인 에러(NoActiveStampError)로 변경

## 🔍 테스트 및 확인 사항
- 리뷰 작성 성공
- 스탬프 없을 시 도메인 에러 반환 확인
- 리뷰 수정 및 삭제 API 정상 작동 확인

## 🙋 기타 참고 사항
- 프론트에서 리뷰 작성 실패 시 인증 에러로 처리되던 문제 → 스탬프 조건 미충족으로 인해 발생했던 오류임 (에러 타입 변경됨)
- Swagger 문서에서 delete: 들여쓰기가 맞지 않아, 정상적으로 수정함