### PR TITLE
스탬프 정책 구현, 전화번호 인증 에러 처리 수정

### DIFF
--- a/prisma/migrations/20250801075559_remove_reward_description/migration.sql
+++ b/prisma/migrations/20250801075559_remove_reward_description/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `reward_description` on the `stamp_policies` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE `stamp_policies` DROP COLUMN `reward_description`;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -275,7 +275,6 @@ model StampPolicy {
   discountAmount    Int?         @map("discount_amount")  
   menuId            Int?         @map("menu_id")          
 
-  rewardDescription String    @map("reward_description") @db.VarChar(255)
   hasExpiry         Boolean   @default(false) @map("has_expiry")
   rewardExpiresAt   DateTime? @map("reward_expires_at")   
 

--- a/src/config/passport.js
+++ b/src/config/passport.js
@@ -18,7 +18,7 @@ passport.use(
     console.log("🔥 [jwtPayload]:", jwtPayload);
     try {
       const user = await prisma.user.findUnique({
-        where: { id: parseInt(jwtPayload.userId, 10) },
+        where: { id: parseInt(jwtPayload.id, 10) },
       });
 
       if (user) {

--- a/src/controllers/admin.stamp.controller.js
+++ b/src/controllers/admin.stamp.controller.js
@@ -1,15 +1,10 @@
 import { uploadStampImagesService } from '../services/admin.stamp.service.js';
 import { createStampPolicy } from '../services/admin.stamp.service.js';
+
 export const uploadStampImages = async (req, res, next) => {
   try {
     const userId = req.user.id;
-    const files = req.files;
-
-    if (!files || files.length === 0) {
-      return res.status(400).json({ message: '이미지 파일이 없습니다.' });
-    }
-
-    const imageUrls = await uploadStampImagesService(userId, files);
+    const imageUrls = await uploadStampImagesService(userId, req.files);
 
     res.status(201).json({
       message: '스탬프 이미지 업로드 성공',

--- a/src/errors/customErrors.js
+++ b/src/errors/customErrors.js
@@ -475,6 +475,18 @@ export class InvalidStampPolicyError extends CustomError {
   }
 }
 
+export class StampImageLimitExceededError extends CustomError {
+  constructor(reason = '스탬프 이미지는 최대 2개까지만 업로드할 수 있습니다..', data = null) {
+    super(reason, 'INVALID_STAMP_IMAGE', 400, data);
+  }
+}
+
+export class NoStampImageError extends CustomError {
+  constructor(reason = '업로드할 이미지가 없습니다.', data = null) {
+    super(reason, 'NOT_FOUND_STAMP_IMAGE', 404, data);
+  }
+}
+
 // 5. 등록 완료
 export class CafeAlreadyCompletedError extends CustomError {
   constructor(cafeId) {

--- a/src/services/auth.service.js
+++ b/src/services/auth.service.js
@@ -104,7 +104,7 @@ export const signupService = async (body) => {
   const roles = userRoles.map((r) => r.role);
 
   const token = jwt.sign(
-    { userId: user.id.toString(), roles },
+    { id: user.id.toString(), roles },
     process.env.JWT_SECRET,
     { expiresIn: "7d" }
   );
@@ -148,7 +148,7 @@ export const loginService = async (email, password, requestedRole) => {
   }
 
   const token = jwt.sign(
-    { userId: user.id.toString(), roles, currentRole: requestedRole },
+    { id: user.id.toString(), roles, currentRole: requestedRole },
     process.env.JWT_SECRET,
     { expiresIn: "7d" }
   );

--- a/src/services/user.service.js
+++ b/src/services/user.service.js
@@ -187,14 +187,19 @@ export const savePhoneNumberAfterVerificationService = async (userId, phoneNumbe
     throw new BadRequestError();
   }
 
-  const existing = await prisma.user.findUnique({ where: { phoneNumber } });
+   // 전화번호가 이미 있는지 확인
+  const existing = await prisma.user.findUnique({
+    where: { phoneNumber },
+  });
 
-  if (existing && existing.id !== Number(userId)) {
-    throw new DuplicateEmailError({ phoneNumber });
+  //  다른 사용자면 에러
+  if (existing && existing.id !== parsedUserId) {
+    throw new DuplicateEmailError({ phoneNumber }); // 409
   }
 
+  // 동일한 사용자라면 가능하게
   const updatedUser = await prisma.user.update({
-    where: { id: Number(userId) },
+    where: { id: parsedUserId },
     data: { phoneNumber },
   });
 

--- a/src/utils/s3.js
+++ b/src/utils/s3.js
@@ -8,17 +8,25 @@ const s3 = new S3Client({
   },
 });
 
+// 원하는 폴더명 지정 가능 (stamps/, menus/, reviews/...)
+/**
+ * @param {Express.Multer.File} file - multer로 받은 단일 파일 객체
+ * @param {string} folder - S3에 저장할 폴더명 (예: 'stamps', 'reviews')
+ * @returns {string} S3에 저장된 파일의 public URL
+ */
 export const uploadToS3 = async (file) => {
+  const fileKey = `${folder}/${Date.now()}_${file.originalname}`;
+
   const uploadParams = {
     Bucket: process.env.AWS_S3_BUCKET,
-    Key: `reviews/${Date.now()}_${file.originalname}`,
+    Key: fileKey,
     Body: file.buffer,
     ContentType: file.mimetype,
   };
 
   const command = new PutObjectCommand(uploadParams);
-  const result = await s3.send(command);
+  await s3.send(command);
   // v3에서는 결과에 Location이 없어서 직접 만들어야 함
-  const location = `https://${uploadParams.Bucket}.s3.${s3.config.region}.amazonaws.com/${uploadParams.Key}`;
+  const location = `https://${uploadParams.Bucket}.s3.${s3.config.region}.amazonaws.com/${fileKey}`;
   return location;
 };


### PR DESCRIPTION
## 📌 작업 개요
- 스탬프 사진 저장 기능 구현
- 스탬프 정책 저장 기능 구현
- 전화번호 재인증 허용

## ✅ 작업 상세 내용
- 스탬프 사진 S3에 저장 로직 구현
- S3에 폴더명 param 설정 추가
- 스탬프정책 테이블 필드 수정
- 전화번호 같은 사용자가 요청하는 경우 재인증 가능하게 수정

## 🔍 테스트 및 확인 사항
- 스탬프 정책은 로컬 테스트 완료

## 📂 관련 이슈
- X

## 🙋 기타 참고 사항
- X
