### PR TITLE
feat: 스탬프 목표 달성 시 쿠폰 발급 및 새 스탬프북 생성

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -2984,6 +2984,47 @@ paths:
                 schema:
                   $ref: '#/components/schemas/ErrorResponse'
 
+  /api/v1/user-coupons/{userCouponId}:
+    patch:
+      tags:
+        - UserCoupons
+      summary: 쿠폰 사용 처리
+      description: 사용자가 보유한 쿠폰을 사용 처리합니다. 사용된 쿠폰은 더 이상 사용할 수 없습니다.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: userCouponId
+          in: path
+          required: true
+          description: 사용 처리할 쿠폰 ID
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: 쿠폰 사용 처리 성공
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: 쿠폰 사용 처리 성공
+                  coupon:
+                    $ref: '#/components/schemas/UserCoupon'
+        '400':
+          description: 이미 사용되었거나 만료된 쿠폰
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: 쿠폰을 찾을 수 없음
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   /api/v1/cafe/{cafeId}/review:
       post:
         tags:
@@ -3001,36 +3042,6 @@ paths:
             description: 리뷰를 작성할 카페 ID
         requestBody:
           required: true
-
-              type: object
-              required:
-                - title
-                - content
-              properties:
-                title:
-                  type: string
-                  example: "카페 분위기도 좋고 사장님도 친절하셔서 추천해요!"
-                content:
-                  type: string
-                  example: >
-                    카페 위치가 조용한 골목에 있어 외부 소음이 거의 없어 집중하기에 정말 좋은 환경이었습니다.
-                    실내는 깔끔하게 정돈되어 있었고, 인테리어는 따뜻한 우드톤과 식물들로 아늑한 분위기를 자아냈습니다.
-                    커피는 원두 맛이 살아있고 풍미가 깊었으며, 디저트류도 정성스럽게 만들어진 느낌이 들었습니다.
-                    특히 사장님께서 추천해주신 시그니처 음료가 매우 인상 깊었고, 매장에서 흐르는 음악도 분위기와 잘 어울려서 오랜 시간 머물기에도 편안했어요.
-                    콘센트와 와이파이도 잘 갖춰져 있어서 노트북 작업하기에 부족함이 없었습니다.
-                    좌석 간 간격이 넓어 프라이버시도 잘 지켜졌고, 무엇보다 직원분들의 친절한 응대가 기억에 남습니다.
-                    다음에도 꼭 다시 방문하고 싶고, 지인들에게도 추천하고 싶은 카페입니다.
-                    별점을 5개 이상 줄 수 있다면 주고 싶을 정도로 만족스러운 경험이었습니다.
-                images:
-                  type: array
-                  items:
-                    type: string
-                    format: binary
-                  description: 첨부 이미지 파일 (최대 5장)
-      responses:
-        '201':
-          description: 리뷰 작성 성공
-
           content:
             multipart/form-data:
               schema:
@@ -3041,11 +3052,18 @@ paths:
                 properties:
                   title:
                     type: string
-                    example: "카페 분위기가 너무 좋아요!"
+                    example: "카페 분위기도 좋고 사장님도 친절하셔서 추천해요!"
                   content:
                     type: string
                     example: >
-                      커피 맛도 좋고 조용해서 공부하기 좋았어요. 다음에 또 방문할 예정입니다.
+                      카페 위치가 조용한 골목에 있어 외부 소음이 거의 없어 집중하기에 정말 좋은 환경이었습니다.
+                      실내는 깔끔하게 정돈되어 있었고, 인테리어는 따뜻한 우드톤과 식물들로 아늑한 분위기를 자아냈습니다.
+                      커피는 원두 맛이 살아있고 풍미가 깊었으며, 디저트류도 정성스럽게 만들어진 느낌이 들었습니다.
+                      특히 사장님께서 추천해주신 시그니처 음료가 매우 인상 깊었고, 매장에서 흐르는 음악도 분위기와 잘 어울려서 오랜 시간 머물기에도 편안했어요.
+                      콘센트와 와이파이도 잘 갖춰져 있어서 노트북 작업하기에 부족함이 없었습니다.
+                      좌석 간 간격이 넓어 프라이버시도 잘 지켜졌고, 무엇보다 직원분들의 친절한 응대가 기억에 남습니다.
+                      다음에도 꼭 다시 방문하고 싶고, 지인들에게도 추천하고 싶은 카페입니다.
+                      별점을 5개 이상 줄 수 있다면 주고 싶을 정도로 만족스러운 경험이었습니다.
                   images:
                     type: array
                     items:
@@ -5346,43 +5364,76 @@ components:
       properties:
         id:
           type: integer
+          example: 12
         userId:
           type: integer
+          example: 3
         couponTemplateId:
           type: integer
+          example: 7
         acquisitionType:
           type: string
-          enum: [stamp, promotion]
+          enum: [promotion, stamp]
+          example: stamp
         status:
           type: string
           enum: [active, used, expired]
+          example: active
         issuedAt:
           type: string
           format: date-time
+        usedAt:
+          type: string
+          format: date-time
+          nullable: true
         expiredAt:
           type: string
           format: date-time
         couponTemplate:
-          type: object
-          properties:
-            id:
-              type: integer
-            cafeId:
-              type: integer
-            name:
-              type: string
-            discountType:
-              type: string
-              enum: [AMOUNT, PERCENT]
-            discountValue:
-              type: number
-            validDays:
-              type: integer
-            isActive:
-              type: boolean
-            expiredAt:
-              type: string
-              format: date-time
+          $ref: '#/components/schemas/CouponTemplate'
+
+    
+    CouponTemplate:
+      type: object
+      properties:
+        id:
+          type: integer
+          example: 7
+        cafeId:
+          type: integer
+          example: 1
+        name:
+          type: string
+          example: 아메리카노 무료 쿠폰
+        discountType:
+          type: string
+          enum: [DISCOUNT, FREE_DRINK, SIZE_UP]
+          description: 쿠폰의 할인 유형
+          example: FREE_DRINK
+        discountValue:
+          type: integer
+          nullable: true
+          description: DISCOUNT 타입일 경우 할인 금액
+          example: 1500
+        applicableMenuId:
+          type: integer
+          nullable: true
+          description: FREE_DRINK 또는 SIZE_UP일 경우 적용 대상 메뉴 ID
+          example: 3
+        validDays:
+          type: integer
+          nullable: true
+          example: 14
+        isActive:
+          type: boolean
+          example: true
+        expiredAt:
+          type: string
+          format: date-time
+        createdAt:
+          type: string
+          format: date-time
+
 
   securitySchemes:
       bearerAuth:

--- a/prisma/migrations/20250801094419_add_default_goal_count/migration.sql
+++ b/prisma/migrations/20250801094419_add_default_goal_count/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE `stamp_books` MODIFY `goal_count` INTEGER NOT NULL DEFAULT 10;

--- a/prisma/migrations/20250801114439_update_discount_type_and_remove_unique/migration.sql
+++ b/prisma/migrations/20250801114439_update_discount_type_and_remove_unique/migration.sql
@@ -1,0 +1,17 @@
+/*
+  Warnings:
+
+  - The values [FREE_ITEM] on the enum `coupon_templates_type` will be removed. If these variants are still used in the database, this will fail.
+
+*/
+-- DropForeignKey
+ALTER TABLE `stamp_books` DROP FOREIGN KEY `stamp_books_user_id_fkey`;
+
+-- DropIndex
+DROP INDEX `stamp_books_user_id_cafe_id_key` ON `stamp_books`;
+
+-- AlterTable
+ALTER TABLE `coupon_templates` MODIFY `type` ENUM('DISCOUNT', 'FREE_DRINK', 'SIZE_UP') NOT NULL;
+
+-- AddForeignKey
+-- ALTER TABLE `point_transactions` ADD CONSTRAINT `point_transactions_user_id_fkey` FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -217,7 +217,7 @@ model StampBook {
   userId            Int                @map("user_id")
   cafeId            Int                @map("cafe_id")
   currentCount      Int                @default(0) @map("current_count")
-  goalCount         Int                @map("goal_count")
+  goalCount         Int                @default(10) @map("goal_count")
   rewardDetail      String             @map("reward_detail") @db.VarChar(255)
   startedAt         DateTime           @map("started_at")
   lastVisitedAt     DateTime?          @map("last_visited_at")
@@ -238,7 +238,6 @@ model StampBook {
   stamps            Stamp[]
   pointTransactions PointTransaction[]
 
-  @@unique([userId, cafeId])
   @@map("stamp_books")
 }
 
@@ -439,9 +438,9 @@ model CouponTemplate {
   cafeId           Int          @map("cafe_id")
   name             String       @db.VarChar(255)
   validDays        Int          @map("valid_days")
-  discountType     DiscountType @map("type") // "DISCOUNT" | "FREE_ITEM" | "SIZE_UP"
+  discountType     DiscountType @map("type") // "DISCOUNT" | "FREE_DRINK" | "SIZE_UP"
   discountValue    Int?         @map("discount_value")       // DISCOUNT일 때만 사용
-  applicableMenuId Int?         @map("applicable_menu_id")   // FREE_ITEM, SIZE_UP일 때만 사용
+  applicableMenuId Int?         @map("applicable_menu_id")   // FREE_DRINK, SIZE_UP일 때만 사용
   isActive         Boolean      @default(true) @map("is_active")
   expiredAt        DateTime     @map("expired_at")
   createdAt        DateTime     @default(now()) @map("created_at")
@@ -520,7 +519,7 @@ enum NotificationType {
 
 enum DiscountType {
   DISCOUNT     // 금액 할인
-  FREE_ITEM    // 특정 메뉴 무료 제공
+  FREE_DRINK    // 특정 메뉴 무료 제공
   SIZE_UP      // 사이즈 업그레이드
 }
 

--- a/src/app.js
+++ b/src/app.js
@@ -64,7 +64,7 @@ app.use("/api/v1/search", searchRouter);
 app.use("/api/v1/cafes/:cafeId", cafeRouter);
 app.use("/api/v1", notificationRouter);
 app.use("/api/v1/points", pointRouter);
-app.use("/api/v1/stampbooks", stampbookRouter);
+app.use("/api/v1", stampbookRouter);
 
 // 사장용
 app.use("/api/v1/owners/cafes", adminCafeRouter);

--- a/src/config/passport.js
+++ b/src/config/passport.js
@@ -18,7 +18,7 @@ passport.use(
     console.log("🔥 [jwtPayload]:", jwtPayload);
     try {
       const user = await prisma.user.findUnique({
-        where: { id: parseInt(jwtPayload.id, 10) },
+        where: { id: parseInt(jwtPayload.userId, 10) },
       });
 
       if (user) {

--- a/src/controllers/stampbook.controller.js
+++ b/src/controllers/stampbook.controller.js
@@ -1,4 +1,4 @@
-import { stampBookService } from "../services/stampbook.service.js";
+import { stampBookService, useUserCouponService } from "../services/stampbook.service.js";
 
 export const issueRewardCoupon = async (req, res, next) => {
   try {
@@ -9,6 +9,22 @@ export const issueRewardCoupon = async (req, res, next) => {
     return res.success({
       message: "리워드 쿠폰 발급 성공",
       coupon,
+    });
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const useUserCouponController = async (req, res, next) => {
+  try {
+    const userId = req.user.userId;
+    const userCouponId = parseInt(req.params.userCouponId, 10);
+
+    const updatedCoupon = await useUserCouponService(userId, userCouponId);
+
+    return res.status(200).json({
+      message: "쿠폰 사용 완료",
+      data: updatedCoupon,
     });
   } catch (err) {
     next(err);

--- a/src/errors/customErrors.js
+++ b/src/errors/customErrors.js
@@ -351,9 +351,9 @@ export class NoActiveStampError extends CustomError {
 
 // 스탬프북 관련
 export class StampNotEligibleError extends CustomError {
-  constructor(userId, cafeId) {
+  constructor(userId, cafeId, goalCount, currentCount) {
     super(
-      `스탬프 목표를 아직 달성하지 않았거나 이미 완료된 상태입니다. userId: ${userId}, cafeId: ${cafeId}`,
+      `스탬프 목표를 아직 달성하지 않았거나 이미 완료된 상태입니다. userId: ${userId}, cafeId: ${cafeId}, goalCount: ${goalCount}, currentCount: ${currentCount}`,
       "ST001",
       400,
       { userId, cafeId, goalCount, currentCount }

--- a/src/errors/customErrors.js
+++ b/src/errors/customErrors.js
@@ -255,6 +255,28 @@ export class DuplicateCouponError extends CustomError {
   }
 }
 
+export class UserCouponNotFoundError extends CustomError {
+  constructor(userCouponId) {
+    super(
+      `사용자 쿠폰을 찾을 수 없습니다. ID: ${userCouponId}`,
+      "C010",
+      404,
+      { userCouponId }
+    );
+  }
+}
+
+export class UserCouponAlreadyUsedOrExpiredError extends CustomError {
+  constructor(userCouponId) {
+    super(
+      `해당 쿠폰은 이미 사용되었거나 만료되었습니다.`,
+      "C011",
+      400,
+      { userCouponId }
+    );
+  }
+}
+
 //검색 라우터
 export class MissingUserCoordinate extends CustomError {
   constructor(message) {

--- a/src/errors/customErrors.js
+++ b/src/errors/customErrors.js
@@ -356,7 +356,7 @@ export class StampNotEligibleError extends CustomError {
       `스탬프 목표를 아직 달성하지 않았거나 이미 완료된 상태입니다. userId: ${userId}, cafeId: ${cafeId}`,
       "ST001",
       400,
-      { userId, cafeId }
+      { userId, cafeId, goalCount, currentCount }
     );
   }
 }

--- a/src/routes/stampbook.routes.js
+++ b/src/routes/stampbook.routes.js
@@ -1,10 +1,15 @@
 import express from "express";
-import { issueRewardCoupon } from "../controllers/stampbook.controller.js";
+import { issueRewardCoupon, useUserCouponController } from "../controllers/stampbook.controller.js";
 import { authenticateJWT } from "../middlewares/authMiddleware.js";
 
 const router = express.Router();
 router.use(authenticateJWT);
+ 
+// 스탬프북 쿠폰 발급 라우트
+router.post("/stampbooks/:cafeId/coupon", issueRewardCoupon);
 
-router.post("/:cafeId/coupon", issueRewardCoupon);
+// 쿠폰 사용 라우트
+router.patch("/user-coupons/:userCouponId", useUserCouponController);
 
 export default router;
+

--- a/src/services/stampbook.service.js
+++ b/src/services/stampbook.service.js
@@ -1,38 +1,56 @@
 import prisma from "../../prisma/client.js";
-import { StampNotEligibleError } from "../errors/customErrors.js";
+import { StampNotEligibleError,
+         UserCouponNotFoundError,
+         UserCouponAlreadyUsedOrExpiredError,
+} from "../errors/customErrors.js";
 
+// 스탬프북 쿠폰 발급 서비스
 export const stampBookService = {
   async handleStampCompletion(userId, cafeId) {
-    const stampBook = await prisma.stampBook.findUnique({
+    const stampBook = await prisma.stampBook.findFirst({
       where: {
-        userId_cafeId: { userId, cafeId },
+        userId,
+        cafeId,
+        isCompleted: false, // 아직 완료되지 않은 스탬프북
       },
     });
 
     if (
       !stampBook ||
       stampBook.isCompleted ||
-      stampBook.currentCount < stampBook.goalCount
+      typeof stampBook.currentCount !== "number" || // null 방지
+      stampBook.currentCount < 10
     ) {
       throw new StampNotEligibleError(
         userId,
         cafeId,
-        stampBook?.goalCount ?? null,
+        10,
         stampBook?.currentCount ?? null
       );
     }
-
+    const stampPolicy = await prisma.stampPolicy.findUnique({
+      where: { cafeId },
+    });    
     const now = new Date();
-    const expiredAt = new Date(now.getTime() + 14 * 24 * 60 * 60 * 1000); // +14일
+    const expiredAt = new Date(now.getTime() + 14 * 24 * 60 * 60 * 1000); // 예: 기본 14일 후
+    const rewardToDiscountTypeMap = {
+      DISCOUNT: "DISCOUNT",
+      FREE_DRINK: "FREE_DRINK",
+      SIZE_UP: "SIZE_UP",
+    };
 
     const couponTemplate = await prisma.couponTemplate.create({
       data: {
         cafeId,
-        name: stampBook.rewardDetail || "스탬프 리워드 쿠폰",
-        discountType: "AMOUNT",
-        discountValue: 0,
+        name: stampPolicy.rewardDescription || "스탬프 리워드 쿠폰",
+        discountType: rewardToDiscountTypeMap[stampPolicy.rewardType],
+        discountValue: stampPolicy.discountAmount ?? 0,
+        applicableMenuId: stampPolicy.menuId ?? null,
         isActive: true,
-        expiredAt,
+        validDays: stampPolicy.hasExpiry ? null : 14, // ❗선택적 처리
+        expiredAt: stampPolicy.hasExpiry
+          ? stampPolicy.rewardExpiresAt
+          : new Date(Date.now() + 14 * 24 * 60 * 60 * 1000), // 기본 14일
       },
     });
 
@@ -59,6 +77,54 @@ export const stampBookService = {
       },
     });
 
+    // ✅ 새로운 스탬프북 자동 생성
+    const newStampBook = await prisma.stampBook.create({
+      data: {
+        userId,
+        cafeId,
+        currentCount: 0,
+        goalCount: 10,
+        status: "active",
+        startedAt: now,
+        rewardDetail: stampPolicy.rewardDescription || "스탬프 리워드 쿠폰",
+        expiredAt: stampPolicy.hasExpiry
+          ? stampPolicy.rewardExpiresAt
+          : new Date(Date.now() + 14 * 24 * 60 * 60 * 1000),
+        expiresAt: new Date(now.getTime() + 30 * 24 * 60 * 60 * 1000),
+      },
+    });
+    
     return userCoupon;
   },
+};
+
+
+
+// 쿠폰 사용 서비스 (스탬프, 프로모션 포함)
+
+export const useUserCouponService = async (userId, userCouponId) => {
+  const userCoupon = await prisma.userCoupon.findFirst({
+    where: { 
+      id: userCouponId,
+      userId: userId, // 사용자 ID로 필터링
+    },
+  });
+
+  if (!userCoupon) {
+    throw new UserCouponNotFoundError(userCouponId);
+  }
+
+  if (userCoupon.status !== "active") {
+    throw new UserCouponAlreadyUsedOrExpiredError(userCouponId);
+  }
+
+  const now = new Date();
+
+  return await prisma.userCoupon.update({
+    where: { id: userCouponId },
+    data: {
+      status: "used",
+      usedAt: now,
+    },
+  });
 };

--- a/src/services/stampbook.service.js
+++ b/src/services/stampbook.service.js
@@ -14,7 +14,12 @@ export const stampBookService = {
       stampBook.isCompleted ||
       stampBook.currentCount < stampBook.goalCount
     ) {
-      throw new StampNotEligibleError(userId, cafeId);
+      throw new StampNotEligibleError(
+        userId,
+        cafeId,
+        stampBook?.goalCount ?? null,
+        stampBook?.currentCount ?? null
+      );
     }
 
     const now = new Date();


### PR DESCRIPTION
## 📌 작업 개요
- 스탬프 목표 달성 시 리워드 쿠폰 발급 및 스탬프북 갱신 로직 구현

## ✅ 작업 상세 내용
- 스탬프북 목표 도달 시 쿠폰 자동 발급 및 기존 스탬프북 완료 처리
- 완료된 스탬프북 이후 새 스탬프북 자동 생성
- 스탬프북 조건 불충족 시 에러 메시지에 goalCount, currentCount 추가
- DiscountType Enum 수정: FREE_ITEM → FREE_DRINK
- Prisma 스키마 및 마이그레이션 파일 수정
- 쿠폰 사용 및 리뷰 작성 Swagger 문서 추가/수정
- 관련 라우터, 서비스, 컨트롤러, 에러 파일 로직 변경

## 🔍 테스트 및 확인 사항
- 스탬프 목표 도달 시 쿠폰 정상 발급 여부 확인
- 조건 불충족 시 발급 차단되는지 확인
- 새 스탬프북 생성 정상 동작
- Swagger /stampbooks/{cafeId}/coupon POST 경로 확인
- 쿠폰 사용, 리뷰 등록 Swagger 문서 정상 반영 여부 확인

## 🙋 기타 참고 사항
- 다중 스탬프북 생성을 위해 @unique([userId, cafeId]) 제약 제거
- 쿠폰 사용 API는 이후 실제 사용 처리 로직과 연결 예정입니다 (UserCoupon 상태 변경 포함 예정)
- 스탬프 쿠폰 발급 테스트 임의로 스탬프 정책 만들어서 진행했습니다