### PR TITLE
[fix] cafe 테이블에 breakTime 필드 추가 및 연관 코드 변경

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -3410,6 +3410,9 @@ paths:
                         type: string
                       closeTime:
                         type: string
+                breakTime:
+                  type: string
+                  example: "14:00~15:00"
                 storeFilters:
                   type: array
                   items:
@@ -3452,6 +3455,7 @@ paths:
                   isClosed: true
                 - day: "일"
                   isClosed: true
+              breakTime: "14:00~15:00"
               storeFilters:
                 - "1인석"
               takeOutFilters:
@@ -3464,6 +3468,7 @@ paths:
       responses:
         200:
           description: 운영 정보 업데이트 성공
+
 
   /api/v1/owner/cafes/menus:
     post:
@@ -4881,6 +4886,7 @@ components:
         - name
         - address
         - businessHours
+        - breakTime
         - phone
         - websiteUrl
         - description
@@ -4906,6 +4912,10 @@ components:
           items:
             $ref: '#/components/schemas/CafeDetailBusinessHour'
           description: 영업시간 정보
+        breakTime:
+          type: string
+          description: 브레이크 타임
+          example: "14:00~15:00"
         phone:
           type: string
           description: 전화번호

--- a/prisma/migrations/20250806183420_add_break_time_to_cafe/migration.sql
+++ b/prisma/migrations/20250806183420_add_break_time_to_cafe/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[user_id,cafe_id]` on the table `stamp_books` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- AlterTable
+ALTER TABLE `cafes` ADD COLUMN `break_time` VARCHAR(100) NULL;
+
+-- CreateIndex
+CREATE UNIQUE INDEX `stamp_books_user_id_cafe_id_key` ON `stamp_books`(`user_id`, `cafe_id`);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -334,6 +334,7 @@ model Cafe {
   longitude        Float
   ownerName        String     @map("owner_name") @db.VarChar(100)
   businessHours    Json?      @map("business_hours")
+  breakTime        String?    @map("break_time") @db.VarChar(100)
   phone            String?    @db.VarChar(20)
   websiteUrl       String?    @map("website_url") @db.Text
   description      String?    @db.Text

--- a/src/controllers/admin.cafe.controller.js
+++ b/src/controllers/admin.cafe.controller.js
@@ -56,6 +56,7 @@ export const patchCafeOperationInfo = async (req, res, next) => {
         id: updatedCafe.id,
         name: updatedCafe.name,
         businessHours: updatedCafe.businessHours,
+        breakTime: updatedCafe.breakTime,
         storeFilters: updatedCafe.storeFilters,
         takeOutFilters: updatedCafe.takeOutFilters,
         menuFilters: updatedCafe.menuFilters,

--- a/src/services/admin.cafe.service.js
+++ b/src/services/admin.cafe.service.js
@@ -84,6 +84,7 @@ export const updateCafeOperationInfo = async (userId, operationInfo) => {
     where: { id: cafe.id },
     data: {
       businessHours: parsedHours,
+      breakTime: operationInfo.breakTime,
       storeFilters: parseIfString(operationInfo.storeFilters),
       takeOutFilters: parseIfString(operationInfo.takeOutFilters),
       menuFilters: parseIfString(operationInfo.menuFilters),


### PR DESCRIPTION
## 📌 작업 개요
- 카페 운영 정보에 breakTime 필드를 추가, 관련 API 및 Swagger 수정

## ✅ 작업 상세 내용
- Prisma 스키마 Cafe 모델에 breakTime 필드(문자열) 추가
- 카페 운영정보 등록 기능에 브레이크타임 필드 추가
- 카페 조회 기능 등에도 모두 필드 추가

## 🔍 테스트 및 확인 사항
- 테스트 완료

## 📂 관련 이슈
- X

## 🙋 기타 참고 사항
- X
