### PR TITLE
feat: 사장님 카페의 챌린지 통계 조회 API 구현

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -4990,6 +4990,48 @@ paths:
                       completedCount:
                         type: integer
 
+  /api/v1/owner/cafes/{cafeId}/challenges/statistics:
+    get:
+      tags:
+        - Admin Challenges
+      summary: 챌린지 통계 조회
+      description: 매장의 챌린지 참여 수, 참여자 수, 혜택 수령자 수, 챌린지를 통한 판매 건 수를 조회합니다.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: cafeId
+          in: path
+          required: true
+          schema:
+            type: integer
+          description: 매장 ID
+      responses:
+        '200':
+          description: 챌린지 통계 조회 성공
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  resultType:
+                    type: string
+                    example: SUCCESS
+                  data:
+                    type: object
+                    properties:
+                      participatedChallengeCount:
+                        type: integer
+                        example: 5
+                      totalParticipantCount:
+                        type: integer
+                        example: 238
+                      completedUserCount:
+                        type: integer
+                        example: 200
+                      challengeRelatedSalesCount:
+                        type: integer
+                        example: 32
+
 components:
   securitySchemes:
     bearerAuth:

--- a/src/controllers/admin.challenge.controller.js
+++ b/src/controllers/admin.challenge.controller.js
@@ -1,7 +1,9 @@
 import { getAvailableChallengesService,
          joinChallengeService,
          getInProgressChallengesService,
-         getChallengeDetailService } from '../services/admin.challenge.service.js';
+         getChallengeDetailService,
+         getPastChallengesByCafe,
+         getChallengeStatisticsService} from '../services/admin.challenge.service.js';
 
 
 export const getAvailableChallengesController = async (req, res, next) => {
@@ -71,4 +73,13 @@ export const getChallengeDetailController = async (req, res, next) => {
   }
 };
 
+export const getChallengeStatistics = async (req, res, next) => {
+    try {
+      const cafeId = Number(req.params.cafeId);
+      const data = await getChallengeStatisticsService(cafeId); 
+      return res.success(data);
+    } catch (err) {
+      next(err);
+    }
+  };
   

--- a/src/repositories/admin.challenge.repository.js
+++ b/src/repositories/admin.challenge.repository.js
@@ -69,14 +69,13 @@ export const getInProgressChallengesByCafe = async (cafeId) => {
 export const getChallengeDetailByCafe = async (cafeId, challengeId) => {
   return await prisma.challenge.findFirst({
     where: {
-      id: Number(challengeId),
       availableCafes: {
-        some: { cafeId: Number(cafeId) }
+        some: { cafeId: Number(cafeId) } // ← 숫자로 변환
       }
     },
     include: {
       participants: {
-        where: { joinedCafeId: Number(cafeId) }
+        where: { joinedCafeId: Number(cafeId) } // ← 숫자로 변환
       }
     }
   });

--- a/src/routes/admin.challenge.routes.js
+++ b/src/routes/admin.challenge.routes.js
@@ -4,7 +4,8 @@ import { getAvailableChallengesController,
          joinChallengeController,
          getInProgressChallengesController,
          getPastChallengesController,
-         getChallengeDetailController } from '../controllers/admin.challenge.controller.js';
+         getChallengeDetailController,
+         getChallengeStatistics } from '../controllers/admin.challenge.controller.js';
 
 const router = express.Router();
 
@@ -21,6 +22,9 @@ router.get('/:cafeId/challenges/in-progress',getInProgressChallengesController);
 
 // 과거 챌린지 조회
 router.get('/:cafeId/challenges/past', getPastChallengesController);
+
+// 챌린지 통계 조회
+router.get('/:cafeId/challenges/statistics', getChallengeStatistics);
 
 // 챌린지 상세 조회
 router.get('/:cafeId/challenges/:challengeId', getChallengeDetailController);


### PR DESCRIPTION
## 📌 작업 개요
- 사장님 카페의 챌린지 통계 조회 API 구현

## ✅ 작업 상세 내용
- 참여한 챌린지 수, 챌린지에 참여한 유저 수, 챌린지를 완료한 유저 수, 챌린지를 통해 발생한 판매 건수

## 🔍 테스트 및 확인 사항
- Postman 테스트 완료

## 🙋 기타 참고 사항
x
