### PR TITLE
fix: 쿠폰 조회시 카페 정보 응답 수정

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -3209,6 +3209,17 @@ paths:
                           format: date-time
                           nullable: true
                           example: null
+                        cafeId:
+                        type: integer
+                        example: 5
+                        cafeImage:
+                          type: string
+                          nullable: true
+                          example: https://cdn.loopy.com/cafes/5/main.jpg
+                        usageCondition:
+                          type: string
+                          nullable: true
+                          example: 1만원 이상 구매 시
                         couponTemplate:
                           type: object
                           properties:


### PR DESCRIPTION
## 📌 작업 개요
- 사용자 쿠폰 목록 조회 시 cafeId, cafeImage, usageCondition 필드를 응답에 추가

## ✅ 작업 상세 내용
- getUserCoupons 메서드에서 findMany 결과를 map 처리하여 평탄화된 필드(cafeId, cafeImage, usageCondition) 추가
- 기존 couponTemplate.cafe.id, couponTemplate.cafe.photos 데이터를 가공하여 반환
- Swagger 문서(/api/v1/user-coupons) 응답 스키마 수정

## 🔍 테스트 및 확인 사항
- postman 테스트 완료