### PR TITLE
feat: prisma enum import 방식 수정 및 쿠폰 목록 응답에 카페 name 추가

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -3148,6 +3148,10 @@ paths:
                         cafeId:
                           type: integer
                           example: 5
+                        cafeName:
+                          type: string
+                          nullable: true
+                          example: 루피카페
                         cafeImage:
                           type: string
                           nullable: true

--- a/src/services/coupon.service.js
+++ b/src/services/coupon.service.js
@@ -1,6 +1,8 @@
 // coupon.service.js
 import prisma from '../../prisma/client.js';
-import { CouponStatus } from '@prisma/client';
+import pkg from '@prisma/client';
+const { Prisma } = pkg;
+const { CouponStatus } = Prisma;
 
 import {
   CouponMissingDiscountValueError,

--- a/src/services/user.coupon.service.js
+++ b/src/services/user.coupon.service.js
@@ -15,6 +15,7 @@ export const userCouponService = {
           cafe: {
             select: {
               id: true,
+              name: true,
               photos: {
                 orderBy: { displayOrder: 'asc' },
                 take: 1,
@@ -46,6 +47,7 @@ export const userCouponService = {
       return coupons.map((c) => ({
         ...c,
         cafeId: c.couponTemplate?.cafe?.id ?? null,
+        cafeName: c.couponTemplate?.cafe?.name ?? null,
         cafeImage: c.couponTemplate?.cafe?.photos?.[0]?.photoUrl ?? null,
         usageCondition: c.couponTemplate?.usageCondition ?? null,
       }));
@@ -65,6 +67,7 @@ export const userCouponService = {
       return coupons.map((c) => ({
         ...c,
         cafeId: c.couponTemplate?.cafe?.id ?? null,
+        cafeName: c.couponTemplate?.cafe?.name ?? null,
         cafeImage: c.couponTemplate?.cafe?.photos?.[0]?.photoUrl ?? null,
         usageCondition: c.couponTemplate?.usageCondition ?? null,
       }));


### PR DESCRIPTION
## 📌 작업 개요
- Prisma enum CouponStatus ESM 환경에서 import 방식 수정
- 사용자 쿠폰 목록 응답에 cafeName 필드 추가

## ✅ 작업 상세 내용
- ESM + CommonJS 호환성 문제 해결
- couponTemplate.cafe.name 조회 추가

## 🔍 테스트 및 확인 사항
- /api/v1/user-coupons 호출 시 응답 JSON에 cafeName 필드 정상 노출
- 스웨거 문서 반영 완료
