### PR TITLE
feat: 챌린지 전체 조회 및 참여 여부 반환

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -5133,8 +5133,8 @@ paths:
     get:
       tags:
         - Admin Challenges
-      summary: 참여 가능한 챌린지 조회
-      description: 사장님이 아직 참여하지 않은, 현재 참여 가능한 챌린지 목록을 조회합니다.
+      summary: 챌린지 목록 조회
+      description: 기간이 지나지 않은 모든 챌린지를 조회합니다.
       security:
         - bearerAuth: []
       parameters:
@@ -5145,7 +5145,7 @@ paths:
             type: integer
       responses:
         200:
-          description: 참여 가능한 챌린지 목록 조회 성공
+          description: 챌린지 목록 조회 성공
           content:
             application/json:
               schema:

--- a/src/controllers/admin.challenge.controller.js
+++ b/src/controllers/admin.challenge.controller.js
@@ -1,21 +1,20 @@
-import { getAvailableChallengesService,
+import { getAllActiveChallengesService,
          joinChallengeService,
          getInProgressChallengesService,
          getChallengeDetailService,
          getPastChallengesByCafe,
          getChallengeStatisticsService} from '../services/admin.challenge.service.js';
 
-
-export const getAvailableChallengesController = async (req, res, next) => {
+export const getLiveChallengesController = async (req, res, next) => {
   try {
-    const { cafeId } = req.params;
-    const challenges = await getAvailableChallengesService(cafeId);
-    res.status(200).json({
+    const { cafeId } = req.params; // path param
+    const challenges = await getAllActiveChallengesService(cafeId);
+    return res.status(200).json({
       resultType: 'SUCCESS',
       data: challenges,
     });
-  } catch (error) {
-    next(error);
+  } catch (err) {
+    next(err);
   }
 };
 

--- a/src/repositories/admin.challenge.repository.js
+++ b/src/repositories/admin.challenge.repository.js
@@ -1,29 +1,33 @@
 import prisma from '../../prisma/client.js';
 
-export const getAvailableChallengesByCafe = async (cafeId) => {
+export const findAllActiveChallengesByCafe = async (cafeId) => {
   const today = new Date();
 
   const challenges = await prisma.challenge.findMany({
     where: {
       isActive: true,
-      startDate: { lte: today },
-      endDate: { gte: today },
+      endDate: { gte: today }, // 종료일이 오늘 이후
     },
     include: {
       availableCafes: {
         where: { cafeId: Number(cafeId) },
         select: { id: true }
       }
-    }
+    },
+    orderBy: { startDate: 'asc' }
   });
 
   return challenges.map(challenge => ({
     id: challenge.id,
     title: challenge.title,
+    description: challenge.description,
     thumbnailUrl: challenge.thumbnailUrl,
-    startDate: challenge.startDate ? challenge.startDate.toISOString().split('T')[0] : null,
-    endDate: challenge.endDate ? challenge.endDate.toISOString().split('T')[0] : null,
-    isJoined: challenge.availableCafes.length > 0,
+    startDate: challenge.startDate?.toISOString().split('T')[0] ?? null,
+    endDate: challenge.endDate?.toISOString().split('T')[0] ?? null,
+    goalCount: challenge.goalCount,
+    goalDescription: challenge.goalDescription,
+    rewardPoint: challenge.rewardPoint,
+    isJoined: challenge.availableCafes.length > 0
   }));
 };
 

--- a/src/routes/admin.challenge.routes.js
+++ b/src/routes/admin.challenge.routes.js
@@ -1,6 +1,6 @@
 import express from 'express';
 import { authenticateJWT } from '../middlewares/authMiddleware.js';
-import { getAvailableChallengesController,
+import { getLiveChallengesController,
          joinChallengeController,
          getInProgressChallengesController,
          getPastChallengesController,
@@ -11,9 +11,8 @@ const router = express.Router();
 
 router.use(authenticateJWT);
 
-// 참여 가능한 챌린지 조회
-router.get('/:cafeId/challenges/available',getAvailableChallengesController);
-
+// 챌린지 목록 조회
+router.get('/:cafeId/challenges/available', getLiveChallengesController);
 // 챌린지 참여
 router.post('/:cafeId/challenges/:challengeId/join',joinChallengeController);
 

--- a/src/services/admin.challenge.service.js
+++ b/src/services/admin.challenge.service.js
@@ -1,5 +1,5 @@
 import prisma from '../../prisma/client.js';
-import { getAvailableChallengesByCafe,
+import { findAllActiveChallengesByCafe,
          getInProgressChallengesByCafe,
          getChallengeDetailByCafe } from '../repositories/admin.challenge.repository.js';
 import { CafeNotFoundError,
@@ -8,14 +8,14 @@ import { CafeNotFoundError,
          ChallengeUnavailableError } from '../errors/customErrors.js';
 
 // 참여 가능한 챌린지 조회 서비스       
-export const getAvailableChallengesService = async (cafeId) => {
+export const getAllActiveChallengesService = async (cafeId) => {
   const cafe = await prisma.cafe.findUnique({
     where: { id: Number(cafeId) }
   });
 
   if (!cafe) throw new CafeNotFoundError(cafeId);
 
-  return await getAvailableChallengesByCafe(cafeId);
+  return await findAllActiveChallengesByCafe(cafeId);
 };
 
 // 챌린지 참여 서비스


### PR DESCRIPTION
## 📌 작업 개요
- 참여가능한 챌린지 조회 -> 모든 챌린지 목록 조회 (기간 지난 것 제외)

## ✅ 작업 상세 내용
- 모든 챌린지를 조회하되, 기간 지난 챌린지는 제외
- 챌린지 썸네일, 제목, 기간, 참여 여부 반환

## 🔍 테스트 및 확인 사항
- postman 테스트완료
