### PR TITLE
스탬프 사진 저장 개수 제한 로직 수정 

### DIFF
--- a/prisma/migrations/20250814183642_update_fk_to_cascade/migration.sql
+++ b/prisma/migrations/20250814183642_update_fk_to_cascade/migration.sql
@@ -1,15 +1,3 @@
--- DropForeignKey
-ALTER TABLE `challenge_participants` DROP FOREIGN KEY `challenge_participants_joined_cafe_id_fkey`;
-
--- DropForeignKey
-ALTER TABLE `notifications` DROP FOREIGN KEY `notifications_cafe_id_fkey`;
-
--- DropForeignKey
-ALTER TABLE `point_transactions` DROP FOREIGN KEY `point_transactions_stamp_book_id_fkey`;
-
--- DropForeignKey
-ALTER TABLE `user_role` DROP FOREIGN KEY `user_role_userId_fkey`;
-
 -- AlterTable
 ALTER TABLE `cafe_menu` MODIFY `updated_at` DATETIME(3) NULL;
 
@@ -18,25 +6,3 @@ ALTER TABLE `cafes` MODIFY `updated_at` DATETIME(3) NULL;
 
 -- AlterTable
 ALTER TABLE `user_bookmarks` MODIFY `updated_at` DATETIME(3) NULL;
-
--- CreateTable
--- AddForeignKey
-ALTER TABLE `user_role` ADD CONSTRAINT `user_role_userId_fkey` FOREIGN KEY (`userId`) REFERENCES `users`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
-
--- AddForeignKey
-ALTER TABLE `challenge_participants` ADD CONSTRAINT `challenge_participants_joined_cafe_id_fkey` FOREIGN KEY (`joined_cafe_id`) REFERENCES `cafes`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
-
--- AddForeignKey
-ALTER TABLE `stamp_books` ADD CONSTRAINT `stamp_books_user_id_fkey` FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
-
--- AddForeignKey
-ALTER TABLE `point_transactions` ADD CONSTRAINT `point_transactions_stamp_book_id_fkey` FOREIGN KEY (`stamp_book_id`) REFERENCES `stamp_books`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
-
--- AddForeignKey
-ALTER TABLE `notifications` ADD CONSTRAINT `notifications_cafe_id_fkey` FOREIGN KEY (`cafe_id`) REFERENCES `cafes`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
-
--- AddForeignKey
-ALTER TABLE `user_cafe_notifications` ADD CONSTRAINT `user_cafe_notifications_user_id_fkey` FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
-
--- AddForeignKey
-ALTER TABLE `user_cafe_notifications` ADD CONSTRAINT `user_cafe_notifications_cafe_id_fkey` FOREIGN KEY (`cafe_id`) REFERENCES `cafes`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;

--- a/src/services/admin.stamp.service.js
+++ b/src/services/admin.stamp.service.js
@@ -16,6 +16,11 @@ export const uploadStampImagesService = async (userId, files) => {
   }
   const MAX_TOTAL_IMAGES = 4;
 
+  const defaultStampImages = [
+    'https://loopy-bucket.s3.ap-northeast-2.amazonaws.com/cafes/stamps/default/%EA%B8%B0%EB%B3%B8%EC%8A%A4%ED%83%AC%ED%94%84_1.png',
+    'https://loopy-bucket.s3.ap-northeast-2.amazonaws.com/cafes/stamps/default/%EA%B8%B0%EB%B3%B8%EC%8A%A4%ED%83%AC%ED%94%84_2.png',
+  ];
+
   return await prisma.$transaction(async (tx) => {
     const cafe = await tx.cafe.findFirst({
       where: { ownerId: Number(userId) },
@@ -24,10 +29,13 @@ export const uploadStampImagesService = async (userId, files) => {
     if (!cafe) throw new CafeNotFoundError();
 
     const existingCount = await tx.stampImage.count({
-      where: { cafeId: cafe.id },
+      where: {
+        cafeId: cafe.id,
+        imageUrl: { notIn: defaultStampImages },
+      },
     });
 
-    const capacity = MAX_TOTAL_IMAGES - existingCount;
+    const capacity = MAX_TOTAL_IMAGES - defaultStampImages.length - existingCount;
 
     if (capacity <= 0) {
       throw new StampImageLimitExceededError(); 


### PR DESCRIPTION
## 📌 작업 개요
- 스탬프 사진 저장 개수 제한 로직 수정 

## ✅ 작업 상세 내용
- s3에서 개수 확인하는 로직에서 실시간으로 넣어주는 방식으로 수정 

## 🔍 테스트 및 확인 사항
- 머지 후 테스트 가능 

## 📂 관련 이슈
- x

## 🙋 기타 참고 사항
- x
